### PR TITLE
Remove all references to sys.version_info and associated fixups

### DIFF
--- a/src/cothread/catools.py
+++ b/src/cothread/catools.py
@@ -83,12 +83,6 @@ K = 1024
 CA_ACTION_STACK         = _check_env('CATOOLS_ACTION_STACK', 0)
 
 
-if sys.version_info < (3,):
-    pv_string_types = (str, unicode)
-else:
-    pv_string_types = str
-
-
 class ca_nothing(Exception):
     '''This value is returned as a success or failure indicator from caput,
     as a failure indicator from caget, and may be raised as an exception to
@@ -567,7 +561,7 @@ def camonitor(pvs, callback, **kargs):
         if notify_disconnect is False, and that if the PV subsequently connects
         it will update as normal.
     '''
-    if isinstance(pvs, pv_string_types):
+    if isinstance(pvs, str):
         return _Subscription(pvs, callback, **kargs)
     else:
         return [
@@ -754,7 +748,7 @@ def caget(pvs, **kargs):
     The format of values returned depends on the number of values requested
     for each PV.  If only one value is requested then the value is returned
     as a scalar, otherwise as a numpy array.'''
-    if isinstance(pvs, pv_string_types):
+    if isinstance(pvs, str):
         return caget_one(pvs, **kargs)
     else:
         return caget_array(pvs, **kargs)
@@ -827,7 +821,7 @@ def caput_one(pv, value, datatype=None, wait=False, timeout=5, callback=None):
 
 def caput_array(pvs, values, repeat_value=False, **kargs):
     # Bring the arrays of pvs and values into alignment.
-    if repeat_value or isinstance(values, pv_string_types):
+    if repeat_value or isinstance(values, str):
         # If repeat_value is requested or the value is a string then we treat
         # it as a single value.
         values = [values] * len(pvs)
@@ -898,7 +892,7 @@ def caput(pvs, values, **kargs):
     If caput completed succesfully then .ok is True and .name is the
     corresponding PV name.  If throw=False was specified and a put failed
     then .errorcode is set to the appropriate ECA_ error code.'''
-    if isinstance(pvs, pv_string_types):
+    if isinstance(pvs, str):
         return caput_one(pvs, values, **kargs)
     else:
         return caput_array(pvs, values, **kargs)
@@ -1003,7 +997,7 @@ def connect(pvs, **kargs):
         connected to.  If this is set to False then instead for each failing
         PV a sentinel value with .ok == False is returned.
     '''
-    if isinstance(pvs, pv_string_types):
+    if isinstance(pvs, str):
         return connect_one(pvs, **kargs)
     else:
         return connect_array(pvs, **kargs)

--- a/src/cothread/coserver.py
+++ b/src/cothread/coserver.py
@@ -24,14 +24,8 @@ from the SocketServer and BaseHTTPServer modules
 
 import sys
 
-if sys.version_info < (3,):
-    from SocketServer import BaseServer, TCPServer, UDPServer, ThreadingMixIn
-    from BaseHTTPServer import HTTPServer, test as _test
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-
-else:
-    from socketserver import BaseServer, TCPServer, UDPServer, ThreadingMixIn
-    from http.server import HTTPServer, SimpleHTTPRequestHandler, test as _test
+from socketserver import BaseServer, TCPServer, UDPServer, ThreadingMixIn
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test as _test
 
 from . import cothread
 from . import cosocket

--- a/src/cothread/cosocket.py
+++ b/src/cothread/cosocket.py
@@ -186,32 +186,17 @@ class cosocket(object):
     def dup(self):
         return cosocket(_sock=self.__socket.dup())
 
-    if sys.version_info < (3,):
-        @wrap
-        def makefile(self, *args, **kws):
-            # At this point the actual socket '_socket.socket' is wrapped by
-            # either two layers: 'socket.socket' and this class.  or a single
-            # layer: this class.  In order to handle close() properly we must
-            # copy all wrappers, but not the underlying actual socket.
-            sock = getattr(self.__socket, '_sock', None)
-            if sock: # double wrapped
-                copy0 = _socket_socket(None, None, None, sock)
-                copy1 = cosocket(None, None, None, copy0)
-            else: # single wrapped
-                copy1 = cosocket(None, None, None, self.__socket)
-            return _socket._fileobject(copy1, *args, **kws)
-    else:
-        @property
-        def _io_refs(self):
-            return self.__socket._io_refs
+    @property
+    def _io_refs(self):
+        return self.__socket._io_refs
 
-        @_io_refs.setter
-        def _io_refs(self, value):
-            self.__socket._io_refs = value
+    @_io_refs.setter
+    def _io_refs(self, value):
+        self.__socket._io_refs = value
 
-        # Can use the original makefile just so long as we provide the _io_refs
-        # property above.
-        makefile = _socket_socket.makefile
+    # Can use the original makefile just so long as we provide the _io_refs
+    # property above.
+    makefile = _socket_socket.makefile
 
 
 del wrap

--- a/src/cothread/cothread.py
+++ b/src/cothread/cothread.py
@@ -73,6 +73,7 @@ import bisect
 import traceback
 import collections
 import threading
+import _thread
 
 from . import _coroutine
 
@@ -80,11 +81,6 @@ if os.environ.get('COTHREAD_CHECK_STACK'):
     _coroutine.enable_check_stack(True)
 
 from . import coselect
-
-if sys.version_info >= (3,):
-    import _thread
-else:
-    import thread as _thread
 
 
 __all__ = [


### PR DESCRIPTION
In particular, this allows references to unicode in dbr.py to be removed. There is one backwards compatibility change: the now undocumented datatype option `DBR_CHAR_UNICODE` is no longer available.