### PR TITLE
Fix +array deprecation

### DIFF
--- a/docs/user/catools.rst
+++ b/docs/user/catools.rst
@@ -932,11 +932,6 @@ These two classes can be imported from :mod:`cothread.pv`.
 Note that both classes will automatically unsubscribe from their PVs when
 deleted.
 
-..  note::
-
-    Note that both of these classes are still somewhat experimental and may
-    change in future releases.
-
 
 ..  class:: PV(pv, on_update=None, initial_value=None, caput_wait=False, \
     [initial_timeout], **kargs)

--- a/src/cothread/pv.py
+++ b/src/cothread/pv.py
@@ -26,10 +26,7 @@ class _WeakMethod:
 
 class PV(object):
     '''PV wrapper class.  Wraps access to a single PV as a persistent object
-    with simple access methods.  Always contains the latest PV value.
-
-    WARNING!  This API is a work in progress and may change in future releases
-    in incompatible ways.'''
+    with simple access methods.  Always contains the latest PV value.'''
 
     def __init__(self, pv,
             on_update = None, initial_value = None, caput_wait = False,
@@ -108,10 +105,7 @@ class PV(object):
 class PV_array(object):
     '''PV waveform wrapper class.  Wraps access to a list of PVs as a single
     waveform with simple access methods.  This class will only work if all of
-    the PVs are of the same datatype and the same length.
-
-    WARNING!  This API is a work in progress and may change in future releases
-    in incompatible ways.'''
+    the PVs are of the same datatype and the same length.'''
 
     def __init__(self, pvs,
             dtype = float, count = 1, on_update = None, caput_wait = False,

--- a/src/cothread/pv.py
+++ b/src/cothread/pv.py
@@ -158,7 +158,7 @@ class PV_array(object):
             self.on_update(self, index)
 
     def get(self):
-        return +self.__value
+        return numpy.copy(self.__value)
 
     def caget(self, **kargs):
         dtype = kargs.pop('dtype', self.dtype)
@@ -178,10 +178,10 @@ class PV_array(object):
         return catools.caput(self.names, value, **kargs)
 
     value = property(get, caput)
-    ok        = property(lambda self: +self.__ok)
-    timestamp = property(lambda self: +self.__timestamp)
-    severity  = property(lambda self: +self.__severity)
-    status    = property(lambda self: +self.__status)
+    ok        = property(lambda self: numpy.copy(self.__ok))
+    timestamp = property(lambda self: numpy.copy(self.__timestamp))
+    severity  = property(lambda self: numpy.copy(self.__severity))
+    status    = property(lambda self: numpy.copy(self.__status))
 
     @property
     def all_ok(self):

--- a/tests/soft_records.db
+++ b/tests/soft_records.db
@@ -22,3 +22,26 @@ record(calc, "$(P)calc") {
   field(INPA, "$(P)longout CP")
   field(CALC, "A")
 }
+
+record(longout, "$(P)rec1") {
+  field(VAL, "123")
+  field(PINI, "YES")
+}
+
+record(longout, "$(P)rec2") {
+  field(VAL, "456")
+  field(PINI, "YES")
+}
+
+
+record(calc, "$(P)inc1") {
+  field(VAL, "0")
+  field(CALC, "VAL+1")
+  field(SCAN, ".1 second")
+}
+
+record(calc, "$(P)inc2") {
+  field(VAL, "0")
+  field(CALC, "VAL+1")
+  field(SCAN, ".1 second")
+}

--- a/tests/test_pv.py
+++ b/tests/test_pv.py
@@ -1,0 +1,132 @@
+import os
+
+import numpy
+
+from cothread import Sleep
+from cothread.pv import PV, PV_array
+
+if __name__ == '__main__':
+    import counittest
+else:
+    from . import counittest
+
+here = os.path.dirname(__file__)
+
+TIMEOUT = 5
+
+class PVTest(counittest.TestCase):
+    """Test class for pv.py"""
+    maxDiff=None
+    iocexe = 'softIoc'
+    iocload = (
+        (os.path.join(here, 'soft_records.db'), 'P=$(TESTPREFIX)'),
+    )
+    iocpost = "dbl\r"
+
+    def test_pv_get(self):
+        self.assertIOCRunning()
+        pv = PV(self.testprefix + 'rec1')
+        Sleep(0.2)
+        pv.sync(TIMEOUT)
+
+        self.assertEqual(pv.get(), 123)
+
+    def test_pv_ticking(self):
+        self.assertIOCRunning()
+        pv = PV(self.testprefix + 'inc1')
+        Sleep(0.2)
+        pv.sync(TIMEOUT)
+
+        first = pv.get()
+        Sleep(0.2)
+        second = pv.get()
+
+        assert second > first
+
+    def test_pv_caput(self):
+        self.assertIOCRunning()
+        pv = PV(self.testprefix + 'rec1')
+        Sleep(0.2)
+        pv.sync(TIMEOUT)
+
+        pv.caput(111)
+        pv.reset()
+
+        pv.get_next(TIMEOUT)
+
+        self.assertEqual(pv.get(), 111)
+
+    def test_pv_on_update(self):
+        self.assertIOCRunning()
+
+        update_val = None
+        def my_update(val):
+            nonlocal update_val
+            update_val = val.get()
+
+        pv = PV(self.testprefix + 'rec1', on_update=my_update)
+        Sleep(0.2)
+        pv.sync(TIMEOUT)
+        pv.caput(111)
+
+        # Give background caput/ioc processing chance to update
+        Sleep(0.1)
+
+        self.assertEqual(update_val, 111)
+
+    def test_pv_array_get(self):
+        self.assertIOCRunning()
+
+        pvs = [self.testprefix + 'rec1', self.testprefix + 'rec2']
+
+        pva = PV_array(pvs)
+        Sleep(0.2)
+        pva.sync()
+
+        assert numpy.array_equal(pva.get(), [123, 456])
+
+    def test_pv_array_properties(self):
+        self.assertIOCRunning()
+
+        pvs = [self.testprefix + 'rec1', self.testprefix + 'rec2']
+
+        pva = PV_array(pvs)
+        Sleep(0.2)
+        pva.sync()
+
+        assert numpy.array_equal(pva.ok, [True, True])
+        # assert numpy.array_equal(pva.timestamp, []) Can't easily test timestamps
+        assert numpy.array_equal(pva.severity, [0, 0])
+        assert numpy.array_equal(pva.status, [0, 0])
+
+    def test_pv_array_ticking(self):
+        self.assertIOCRunning()
+
+        pvs = [self.testprefix + 'inc1', self.testprefix + 'inc2']
+
+        pva = PV_array(pvs)
+        Sleep(0.2)
+        pva.sync()
+
+        first = pva.get()
+        Sleep(0.2)
+        second = pva.get()
+
+        assert all(numpy.greater(second, first))
+
+
+    def test_pv_array_put(self):
+        self.assertIOCRunning()
+
+        pvs = [self.testprefix + 'rec1', self.testprefix + 'rec2']
+
+        pva = PV_array(pvs)
+        Sleep(0.2)
+        pva.sync()
+
+        new_vals = [444, 555]
+
+        pva.caput(new_vals)
+        Sleep(0.2)
+
+        assert (pva.get()== new_vals).all()


### PR DESCRIPTION
As of numpy 1.25.0 using a "+" on a non-numeric array [is deprecated](https://numpy.org/devdocs/release/1.25.0-notes.html#expired-deprecations). Change all the instances of it in cothread to use `numpy.copy` instead.

Also adds some tests. 

Also removes a warning related to the PV/ PV_array APIs being changed - they've been stable for many years now with no liklihood of them changing.

Fixes #20 