### PR TITLE
Change ARM code to use position independent code

### DIFF
--- a/context/switch-arm.c
+++ b/context/switch-arm.c
@@ -68,7 +68,7 @@ FSIZE(switch_frame)
 FNAME(create_frame)
 "       stmfd   r0!, {r1, r2}\n"       // Save arguments for new coroutine
 "       mov     ip, lr\n"              // Save LR so can use same STM slot
-"       ldr     lr, =action_entry\n"
+"       adr     lr, action_entry\n"
 "       stmfd   r0!, {r4, r5, r6, r7, r8, r9, sl, fp, lr}\n"
 IF_VFP_FP(
 "       fstmfdd r0!, {d8-d15}\n")

--- a/context/switch-arm64.c
+++ b/context/switch-arm64.c
@@ -105,7 +105,12 @@ FSIZE(switch_frame)
 FNAME(create_frame)
 "       stp x1, x2, [x0, #-16]!\n"
 "       mov x16, lr\n"               // Save LR so can use same STP slot
-"       ldr lr, =action_entry\n"
+        // This should be simply
+        //  adr lr,action_entry
+        // but it would appear that on Apple the target for adr needs to be both
+        // local AND known at the instant it is seen by the assembler.  The
+        // reference .1f is an alias for action_entry below to work around this
+"       adr lr, .1f\n"
 "       stp x19, x20, [x0, #-16]!\n"
 "       stp x21, x22, [x0, #-16]!\n"
 "       stp x23, x24, [x0, #-16]!\n"
@@ -118,6 +123,7 @@ FNAME(create_frame)
 "       stp d14, d15, [x0, #-16]!\n"
 "       br  x16\n"
 
+"1:\n"
 "action_entry:\n"
         // Receive control after first switch to new frame.  Top of stack has
         // the saved context and routine to call, switch argument is in r0.


### PR DESCRIPTION
This is all arising from issue #68 and PR #76.  It seems that MacOS Arm64 does not like the use of relocation in the original switch-arm64.c code. This arises from a single instruction
    ldr lr, =action_entry

As action_entry is extremely close to this code this can simply be replaced with
    adr lr, action_entry
for both ARM32 and ARM64.

Apologies to @graeme-winter, this obsoletes your PR #76.  Unfortunately I have no way to test this.  Perhaps you can test this, at least for ARM64?